### PR TITLE
Add CLAUDE.md + docs/game-rules.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+Persistent context for AI agents (and humans) working on this repo. Keep this file current — any PR that changes the architecture updates this file in the same diff.
+
+## What this project is
+
+A multiplayer board game combining Minesweeper and 5-in-a-row (Gomoku). Two players alternate marks on a grid; some fields are hidden mines that erase the opponent's nearby marks when hit; first to 5-in-a-row wins. See [docs/game-rules.md](docs/game-rules.md) for the full rules spec.
+
+## Current status: mid-rewrite
+
+This repo is being rewritten in place. Two stacks currently coexist:
+
+- **Legacy stack (on `master`, currently in production)**: Blazor WASM frontend (`src/Zlebuh.MinTacToe.UI`) on Netlify, a C# ASP.NET API (`src/Zlebuh.MinTacToe.API`) on Fly.io, Supabase (Postgres + Realtime) as the data/transport layer with its schema managed only via the Supabase dashboard (not in this repo).
+- **New stack (being built on the `refactor/supabase-react` branch)**: Supabase remains the DB/Realtime layer but its schema/config now lives in this repo, the C# API is eliminated in favor of Supabase Edge Functions, and the frontend is rewritten in React + TypeScript.
+
+**Do not modify `src/` (the legacy .NET solution) as part of the rewrite** — it stays untouched and deployable from `master` until the final cutover issue. All rewrite work happens on `refactor/supabase-react` and is deleted only in the last cutover step.
+
+## Why this rewrite (decisions + rationale)
+
+- **Supabase stays, but becomes version-controlled.** The DB schema, RLS policies, and Supabase project config previously existed only in the dashboard. Now they're migrations under `supabase/migrations/`, deployed via the Supabase CLI in CI.
+- **The C# API is replaced by Supabase Edge Functions**, not by a self-hosted alternative. The API's only real job was authoritative move validation; everything else it did (a hand-rolled `users` table, per-game host/visitor tokens) was working around not having real auth. Removing it removes a whole deployment target (Fly.io) and a whole set of "is this in sync with the DB" problems.
+- **Anonymous Auth + RLS replaces the token scheme.** The old design checked a client-supplied token string in application code to decide who could move. The new design uses `supabase.auth.signInAnonymously()` for a stable `auth.uid()` per browser, and Postgres Row-Level Security actually enforces who can read/write a game row. Writes to `game_state` go only through Edge Functions using the service-role key — RLS denies direct client writes.
+- **Blazor is replaced by React + TypeScript**, per explicit user preference (better ecosystem for visual design/styling).
+- **The game engine is ported to TypeScript** (`packages/game-engine`) rather than kept in C#, so the exact same validation logic runs both server-side (Edge Functions, authoritative) and client-side (the local/offline 2-player mode, and optimistic UI). One implementation, not two to keep in sync.
+
+## Target repository layout
+
+```
+apps/web/              React + TypeScript + Vite frontend
+packages/game-engine/  Shared TS port of the game rules (grid, mines, win detection, serialization)
+                          used by both Edge Functions and apps/web (local mode)
+supabase/
+  config.toml           Local dev + project config
+  migrations/            SQL schema + RLS policies — the source of truth for the DB
+  functions/
+    create-game/
+    join-game/
+    make-move/
+.github/workflows/
+  ci.yml                 Lint/build/test on PRs into refactor/supabase-react (new, separate from legacy CI)
+  deploy-supabase.yml     supabase db push + functions deploy — gated to push on master only
+  deploy-web.yml          Build + deploy apps/web to Netlify — gated to push on master only
+```
+
+`src/`, `Dockerfile`, `fly.toml`, `render.yaml`, and the legacy `deploy-api-flyio.yml`/`deploy.yml` workflows are removed in the final cutover PR, not before.
+
+## Delivery process
+
+- All rewrite work targets the **`refactor/supabase-react`** branch, not `master`. `master` keeps deploying the legacy stack untouched throughout.
+- The work is broken into GitHub issues, each with its own PR against `refactor/supabase-react`. **Work on the next issue does not start until the current PR is reviewed and merged by the repo owner.** See issues in this repo for the full sequence (roughly: docs → monorepo/CI scaffold → Supabase schema/RLS → game engine port → Edge Functions → frontend core/local mode → frontend online flow → hardening → production deploy automation → cutover).
+- CI is new and separate from the legacy workflows: `.github/workflows/ci.yml` runs on PRs into the feature branch. The real production deploy workflows (`deploy-supabase.yml`, `deploy-web.yml`) are gated to `master` only, so they stay dormant until the feature branch is finally merged — that merge *is* the production cutover, not a separate step.
+- The full architecture/testing plan lives in the project's plan history; this file and `docs/game-rules.md` are the durable, always-current summary of it.
+
+## Testing conventions
+
+- `packages/game-engine`: Vitest, near-100% coverage expected (pure logic, no I/O). Includes property-based tests (`fast-check`) for core invariants, not just example-based tests.
+- `supabase/functions/*`: unit-test the orchestration logic with a mocked Supabase client; integration-test against a real local stack (`supabase start` + `supabase functions serve`) to prove RLS is actually enforced, not just assumed.
+- `apps/web`: component tests (Vitest + React Testing Library) plus Playwright e2e for the full online flow (two browser contexts playing a real game against the local Supabase stack).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ supabase/
 
 - All rewrite work targets the **`refactor/supabase-react`** branch, not `master`. `master` keeps deploying the legacy stack untouched throughout.
 - The work is broken into GitHub issues, each with its own PR against `refactor/supabase-react`. **Work on the next issue does not start until the current PR is reviewed and merged by the repo owner.** See issues in this repo for the full sequence (roughly: docs → monorepo/CI scaffold → Supabase schema/RLS → game engine port → Edge Functions → frontend core/local mode → frontend online flow → hardening → production deploy automation → cutover).
+- **Every unit of work starts on its own new branch, branched from `origin/refactor/supabase-react`** (not from `master`, and not stacked on another in-progress work branch). Open the PR for that branch against `refactor/supabase-react`.
 - CI is new and separate from the legacy workflows: `.github/workflows/ci.yml` runs on PRs into the feature branch. The real production deploy workflows (`deploy-supabase.yml`, `deploy-web.yml`) are gated to `master` only, so they stay dormant until the feature branch is finally merged — that merge *is* the production cutover, not a separate step.
 - The full architecture/testing plan lives in the project's plan history; this file and `docs/game-rules.md` are the durable, always-current summary of it.
 

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -36,7 +36,7 @@ Players are `O` and `X`; `O` always moves first. A move (`coordinate`, `player`)
 4. Target field is not already occupied.
 5. If the field hasn't been generated yet, generate it and its 8 neighbors now (lazy generation — mines are decided per-field, on first visit, not upfront for the whole board).
 6. Mine placement: an ungenerated field becomes a mine with probability `MineProbability`, **unless** fewer than `NoMineMoves` moves have been played so far (first N moves are always safe).
-7. If the target field is a mine: **explode** it (see below). The player who stepped on it keeps their own mark on that field; only the *opponent's* marks within `MinePower` are erased.
+7. If the target field is a mine: **explode** it (see below). The mine erases *the triggering player's own* nearby marks within `MinePower`; the opponent's marks are left untouched.
 8. If the target field is not a mine: place the player's mark normally.
 9. Check win (5-in-a-row) and tie conditions.
 10. Alternate `playerOnTurn` (unless the game just ended).
@@ -56,10 +56,10 @@ Randomness for mine placement is **not seeded** in the legacy implementation —
 
 ## Mine explosion
 
-- When a mine is hit, every field within `MinePower` (Chebyshev/square radius, not just Manhattan-adjacent — i.e. the `(2×MinePower+1)²` square centered on the mine) is affected:
-  - The opponent's marks in that radius are erased (reset to unoccupied).
-  - The mine-placing player's **own** mark, if any is in that radius, is **not** erased — this includes the mine cell itself if the explosion happens to occur adjacent to one of their own prior marks.
-  - `surroundedByNotExplodedMines` is decremented on all affected non-mine fields (this mine no longer counts as a live threat to them).
+- When a mine is hit, every field within `MinePower` (Chebyshev/square radius, not just Manhattan-adjacent — i.e. the `(2×MinePower+1)²` square centered on the mine, excluding the mine cell itself) is affected:
+  - Only marks belonging to the **triggering player** (the one who just stepped on the mine) are erased (reset to unoccupied).
+  - The **opponent's** marks in that radius are left untouched.
+  - `surroundedByNotExplodedMines` is decremented on all affected non-mine fields in the radius (this mine no longer counts as a live threat to them).
 - The set of all coordinates changed by a move (including explosion side-effects) is returned/tracked so the client can highlight what changed — see `changes` in the serialization format below.
 
 ## Game state JSON shape (legacy format — do not carry forward verbatim)
@@ -89,5 +89,5 @@ The legacy `GameSerializer` produces a custom, non-standard shape: the grid is a
 
 The legacy test suites are the executable spec for all of the above — port them case-for-case into the new `packages/game-engine` Vitest suite before considering the port done:
 
-- `GameEngineTests` / `GameControlTests` / `GameOverTests`: turn enforcement, out-of-bounds coordinates, occupied-field rejection, win detection in all 4 axes, tie detection, mine explosion (including the "own mark survives" rule), neighbor generation on first placement.
+- `GameEngineTests` / `GameControlTests` / `GameOverTests`: turn enforcement, out-of-bounds coordinates, occupied-field rejection, win detection in all 4 axes, tie detection, mine explosion (including the "only the triggering player's own marks are erased" rule), neighbor generation on first placement.
 - `GameSerializationTests` / `CoordinateConverterTests` / `GridConverterTests`: round-trip serialization correctness (less relevant verbatim once the JSON shape changes, but the underlying state transitions they exercise are still valid fixtures).

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -1,0 +1,93 @@
+# Game rules & domain spec
+
+This is the reference spec for the game logic, extracted from the current (legacy) C# implementation in `src/Zlebuh.MinTacToe.GameModel`, `src/Zlebuh.MinTacToe.GameEngine`, and `src/Zlebuh.MinTacToe.GameSerialization`. It is the spec the TypeScript port in `packages/game-engine` must match, verified by porting the existing test suites (`GameEngine.Tests`, `GameSerialization.Tests`) case-for-case.
+
+## Board & rules parameters
+
+The `Rules` type carries all tunable parameters. Production games (created via the legacy API's `GameProxy`) use:
+
+| Parameter | Production value | Meaning |
+|---|---|---|
+| `Rows` / `Columns` | 16 / 16 | Board dimensions |
+| `SeriesLength` | 5 | Marks in a row needed to win |
+| `NoMineMoves` | 6 | First N moves placed are guaranteed mine-free |
+| `MinePower` | 1 | Radius (in cells) affected when a mine explodes |
+| `MineProbability` | 0.1 | Probability a newly-generated field is a mine |
+
+These should remain configurable in the port (not hardcoded), since `Rules` is a first-class parameter object in the current design — but the values above are what's actually live in production today.
+
+## Grid representation
+
+- The grid is **sparse**: only fields that have been "generated" (visited by move placement or neighbor-generation) exist; everything else is implicitly empty/ungenerated.
+- Each field (`Field`) tracks:
+  - `player`: `"O"`, `"X"`, or null (unoccupied)
+  - `isMine`: whether this field is a mine
+  - `generated`: whether this field has been visited/allocated yet
+  - `hasAllNeighboursGenerated`: whether all 8 neighbors have been generated (set once this field is played on)
+  - `surroundedByNotExplodedMines`: count of adjacent, still-live mines (decremented as neighboring mines explode)
+
+## Turn & move flow
+
+Players are `O` and `X`; `O` always moves first. A move (`coordinate`, `player`) is validated in this order — reproduce this exact order and these exact failure modes in the port:
+
+1. Game is not already over.
+2. It's this player's turn.
+3. Coordinate is within grid bounds.
+4. Target field is not already occupied.
+5. If the field hasn't been generated yet, generate it and its 8 neighbors now (lazy generation — mines are decided per-field, on first visit, not upfront for the whole board).
+6. Mine placement: an ungenerated field becomes a mine with probability `MineProbability`, **unless** fewer than `NoMineMoves` moves have been played so far (first N moves are always safe).
+7. If the target field is a mine: **explode** it (see below). The player who stepped on it keeps their own mark on that field; only the *opponent's* marks within `MinePower` are erased.
+8. If the target field is not a mine: place the player's mark normally.
+9. Check win (5-in-a-row) and tie conditions.
+10. Alternate `playerOnTurn` (unless the game just ended).
+
+Randomness for mine placement is **not seeded** in the legacy implementation — genuinely random per game, not reproducible. Decide deliberately in the port whether to keep this (e.g. for parity testing during the port, inject a seedable PRNG so game sequences can be replayed and diffed against the C# output, even though production remains unseeded).
+
+## Win detection (5-in-a-row)
+
+- Checked from the just-placed coordinate outward, across **4 axes** (horizontal, vertical, and the two diagonals) — each axis walked in both directions from the placed cell and summed.
+- A run stops at: grid boundary, an ungenerated field, a mine, or an opponent's mark.
+- **Mines do not break a run** if they don't stop it per the above — i.e. a mine cell itself doesn't count as "the opponent's mark," so a line of the same player's marks with an intervening mine is not automatically broken by mine-ness alone (double check this exact interaction against the ported test cases — it's the single subtlest rule in the engine, historically implemented via a "walk outward, group opposite directions into 4 master axes" approach).
+- A win triggers as soon as any axis reaches `SeriesLength` consecutive marks belonging to the player who just moved.
+
+## Tie detection
+
+- Full-grid scan: the game is a tie once every non-mine field is occupied (no legal moves remain) and no win has been triggered.
+
+## Mine explosion
+
+- When a mine is hit, every field within `MinePower` (Chebyshev/square radius, not just Manhattan-adjacent — i.e. the `(2×MinePower+1)²` square centered on the mine) is affected:
+  - The opponent's marks in that radius are erased (reset to unoccupied).
+  - The mine-placing player's **own** mark, if any is in that radius, is **not** erased — this includes the mine cell itself if the explosion happens to occur adjacent to one of their own prior marks.
+  - `surroundedByNotExplodedMines` is decremented on all affected non-mine fields (this mine no longer counts as a live threat to them).
+- The set of all coordinates changed by a move (including explosion side-effects) is returned/tracked so the client can highlight what changed — see `changes` in the serialization format below.
+
+## Game state JSON shape (legacy format — do not carry forward verbatim)
+
+The legacy `GameSerializer` produces a custom, non-standard shape: the grid is a flat array of alternating `"row,col"` coordinate strings and field objects (not a normal JSON object/map), because .NET's default JSON serialization doesn't handle `Dictionary<Coordinate, Field>` keys the way this format needed:
+
+```json
+{
+  "gameState": {
+    "grid": [
+      "0,0", { "player": "O", "isMine": false, "generated": true, "hasAllNeighboursGenerated": true, "surroundedByNotExplodedMines": 1 },
+      "1,2", { "player": "X", "isMine": true, "generated": false, "hasAllNeighboursGenerated": false, "surroundedByNotExplodedMines": 0 }
+    ],
+    "isGameOver": true,
+    "winner": "O",
+    "playerOnTurn": "X",
+    "changes": ["0,0", "1,2"],
+    "movesPlayed": 7
+  },
+  "rules": { "rows": 16, "columns": 16, "seriesLength": 5, "noMineMoves": 6, "minePower": 1, "mineProbability": 0.1 }
+}
+```
+
+**This shape does not need to be preserved.** Since `game_state` is moving to a real `jsonb` column with no legacy readers, the TypeScript port should use a straightforward JSON object (e.g. `{ [coordinateKey: string]: Field }`) instead of the alternating-array workaround. Keep `isGameOver`, `winner`, `playerOnTurn`, `changes`, and `movesPlayed` (or equivalents) — the frontend's realtime update handling depends on knowing what just changed, not just the full state.
+
+## What the tests already encode (port these first)
+
+The legacy test suites are the executable spec for all of the above — port them case-for-case into the new `packages/game-engine` Vitest suite before considering the port done:
+
+- `GameEngineTests` / `GameControlTests` / `GameOverTests`: turn enforcement, out-of-bounds coordinates, occupied-field rejection, win detection in all 4 axes, tie detection, mine explosion (including the "own mark survives" rule), neighbor generation on first placement.
+- `GameSerializationTests` / `CoordinateConverterTests` / `GridConverterTests`: round-trip serialization correctness (less relevant verbatim once the JSON shape changes, but the underlying state transitions they exercise are still valid fixtures).


### PR DESCRIPTION
Closes #2.

Adds:
- `CLAUDE.md` — architecture overview, decisions + rationale, target repo layout, delivery process (feature branch + one-issue-per-PR with approval gate), testing conventions.
- `docs/game-rules.md` — the full domain spec (grid/rules params, turn/move flow, win detection, mine explosion, legacy JSON shape) extracted from `src/Zlebuh.MinTacToe.GameModel`/`GameEngine`/`GameSerialization`, to serve as the reference for the TypeScript engine port in a later issue.

No code changes. This is issue 1 of 10 in the Supabase-native rewrite — see #2 through #11 for the full sequence. Per the agreed process, I'll wait for this to be reviewed/merged before starting issue #3 (monorepo scaffold + CI).