### PR TITLE
Supabase schema/RLS migration + local dev docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and fill in from `supabase status` (after `supabase start`).
+VITE_SUPABASE_ANON_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,27 @@ jobs:
 
       - run: pnpm --filter web lint
       - run: pnpm --filter web build
+
+  supabase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - uses: supabase/setup-cli@v2
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: supabase start
+
+      - run: pnpm --filter @mintactoe/supabase-tests lint
+      - run: pnpm --filter @mintactoe/supabase-tests test
+
+      - run: supabase stop
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,37 @@ jobs:
           cache: 'pnpm'
 
       - uses: supabase/setup-cli@v2
+        id: setup-cli
+
+      - id: cache-supabase-images
+        uses: actions/cache@v6
+        with:
+          path: ~/supabase-docker-images.tar
+          key: supabase-docker-images-${{ runner.os }}-${{ steps.setup-cli.outputs.version }}
+
+      # Loads previously-saved images into the (empty, on a fresh runner) local Docker daemon
+      # so `supabase start` below sees them as "already present" and skips pulling entirely.
+      - name: Load cached Supabase Docker images
+        if: steps.cache-supabase-images.outputs.cache-hit == 'true'
+        run: docker load -i ~/supabase-docker-images.tar
 
       - run: pnpm install --frozen-lockfile
 
       - run: supabase start
+
+      # Only runs on a cache miss (first run, or the CLI version bumped and pulled different
+      # image tags). Safe to snapshot every image present: the runner's Docker daemon starts
+      # empty, so at this point it holds exactly what `supabase start` just pulled.
+      - name: Save Supabase Docker images to cache
+        if: steps.cache-supabase-images.outputs.cache-hit != 'true'
+        run: docker save $(docker images -q) -o ~/supabase-docker-images.tar
+
+      - name: Export local Supabase URL/keys as env vars
+        run: |
+          eval "$(supabase status -o env)"
+          echo "SUPABASE_URL=$API_URL" >> "$GITHUB_ENV"
+          echo "SUPABASE_ANON_KEY=$ANON_KEY" >> "$GITHUB_ENV"
+          echo "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY" >> "$GITHUB_ENV"
 
       - run: pnpm --filter @mintactoe/supabase-tests lint
       - run: pnpm --filter @mintactoe/supabase-tests test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,5 +78,6 @@ Running the frontend natively instead of in Docker also works: `pnpm --filter we
 ## Testing conventions
 
 - `packages/game-engine`: Vitest, near-100% coverage expected (pure logic, no I/O). Includes property-based tests (`fast-check`) for core invariants, not just example-based tests.
-- `supabase/functions/*`: unit-test the orchestration logic with a mocked Supabase client; integration-test against a real local stack (`supabase start` + `supabase functions serve`) to prove RLS is actually enforced, not just assumed.
+- `packages/supabase-tests`: integration tests that hit a real local Supabase stack via `@supabase/supabase-js` (real anonymous sign-ins, real REST calls) to prove RLS + table grants are actually enforced, not just assumed from reading the migration SQL. **Requires `supabase start` running first** — this is the one package where `pnpm test`/`pnpm -r test` needs live local infra, unlike `game-engine`/`web`. Runs in CI as its own job (`.github/workflows/ci.yml`), which starts the stack itself via `supabase/setup-cli` + `supabase start`.
+- `supabase/functions/*` (once they exist): unit-test the orchestration logic with a mocked Supabase client; extend `packages/supabase-tests` (or a similar suite) to integration-test the deployed functions against the real local stack.
 - `apps/web`: component tests (Vitest + React Testing Library) plus Playwright e2e for the full online flow (two browser contexts playing a real game against the local Supabase stack).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,29 @@ supabase/
 - CI is new and separate from the legacy workflows: `.github/workflows/ci.yml` runs on PRs into the feature branch. The real production deploy workflows (`deploy-supabase.yml`, `deploy-web.yml`) are gated to `master` only, so they stay dormant until the feature branch is finally merged — that merge *is* the production cutover, not a separate step.
 - The full architecture/testing plan lives in the project's plan history; this file and `docs/game-rules.md` are the durable, always-current summary of it.
 
+## Local development
+
+One command runs the full new stack locally (Supabase + frontend) against each other:
+
+```
+pnpm dev:full
+```
+
+This just chains `supabase start && docker compose up --build` (see root `package.json`). Equivalent manual steps:
+
+```
+supabase start                          # starts the local Supabase stack (Postgres/Auth/Realtime/Studio),
+                                         # applying supabase/migrations/ automatically
+supabase status                         # shows the local anon key and API URL
+cp .env.example .env                    # then fill in VITE_SUPABASE_ANON_KEY from the above (one-time)
+docker compose up                       # builds and runs apps/web in a dev container with hot reload,
+                                         # pointed at the local Supabase stack via host.docker.internal
+```
+
+The Supabase stack itself is run via `supabase start`, not reimplemented in `docker-compose.yml` — the Supabase CLI already manages its own docker compose stack, version-matched to `supabase/config.toml`, with migrations auto-applied and a Studio UI. `docker-compose.yml` at the repo root only wraps `apps/web`, so the whole app can be exercised end-to-end (including from a phone/another device on the same network, or without a local Node install) without hand-wiring the Supabase containers ourselves.
+
+Running the frontend natively instead of in Docker also works: `pnpm --filter web dev` (after `supabase start`), with the same env vars in `apps/web/.env` — Docker is optional, not required.
+
 ## Testing conventions
 
 - `packages/game-engine`: Vitest, near-100% coverage expected (pure logic, no I/O). Includes property-based tests (`fast-check`) for core invariants, not just example-based tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,5 +79,12 @@ Running the frontend natively instead of in Docker also works: `pnpm --filter we
 
 - `packages/game-engine`: Vitest, near-100% coverage expected (pure logic, no I/O). Includes property-based tests (`fast-check`) for core invariants, not just example-based tests.
 - `packages/supabase-tests`: integration tests that hit a real local Supabase stack via `@supabase/supabase-js` (real anonymous sign-ins, real REST calls) to prove RLS + table grants are actually enforced, not just assumed from reading the migration SQL. **Requires `supabase start` running first** — this is the one package where `pnpm test`/`pnpm -r test` needs live local infra, unlike `game-engine`/`web`. Runs in CI as its own job (`.github/workflows/ci.yml`), which starts the stack itself via `supabase/setup-cli` + `supabase start`.
+  - There are deliberately **no fallback/default values** for `SUPABASE_URL`/`SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY` in the test source, even the well-known local-dev demo keys — missing env throws immediately instead of the suite silently running against a guessed value. To run locally: `supabase start`, then export the three vars from the running stack before invoking the tests:
+    ```
+    eval "$(supabase status -o env)"
+    export SUPABASE_URL="$API_URL" SUPABASE_ANON_KEY="$ANON_KEY" SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY"
+    pnpm --filter @mintactoe/supabase-tests test
+    ```
+    CI does the equivalent itself as a step, after `supabase start`.
 - `supabase/functions/*` (once they exist): unit-test the orchestration logic with a mocked Supabase client; extend `packages/supabase-tests` (or a similar suite) to integration-test the deployed functions against the real local stack.
 - `apps/web`: component tests (Vitest + React Testing Library) plus Playwright e2e for the full online flow (two browser contexts playing a real game against the local Supabase stack).

--- a/apps/web/Dockerfile.dev
+++ b/apps/web/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+WORKDIR /repo
+RUN corepack enable
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/game-engine/package.json packages/game-engine/package.json
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+WORKDIR /repo/apps/web
+EXPOSE 5173
+CMD ["pnpm", "dev", "--host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# Local dev orchestration for the frontend. The Supabase stack itself (Postgres, Auth, Realtime,
+# Studio) is run separately via `supabase start` (the Supabase CLI manages its own docker compose
+# stack internally) - this file just runs apps/web in a dev container pointed at it, so the whole
+# app can be exercised locally without installing Node on the host.
+#
+# Usage:
+#   supabase start          # starts the local Supabase stack (see `supabase status` for the URL/keys)
+#   cp .env.example .env    # fill in VITE_SUPABASE_ANON_KEY from `supabase status`
+#   docker compose up       # starts the frontend dev server on http://localhost:5173
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile.dev
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./apps/web:/repo/apps/web
+      - ./packages/game-engine:/repo/packages/game-engine
+      - /repo/node_modules
+      - /repo/apps/web/node_modules
+      - /repo/packages/game-engine/node_modules
+    environment:
+      VITE_SUPABASE_URL: http://host.docker.internal:54321
+      VITE_SUPABASE_ANON_KEY: ${VITE_SUPABASE_ANON_KEY}
+      CHOKIDAR_USEPOLLING: "true"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter web dev",
+    "dev:full": "supabase start && docker compose up --build",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint"

--- a/packages/supabase-tests/package.json
+++ b/packages/supabase-tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@mintactoe/supabase-tests",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "typescript": "~6.0.2",
+    "vitest": "latest"
+  }
+}

--- a/packages/supabase-tests/src/games-rls.test.ts
+++ b/packages/supabase-tests/src/games-rls.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-// Fixed local-dev demo keys - identical for every fresh `supabase init` project using the
-// default JWT secret, not a real secret. Overridable via env for a non-default local stack.
-const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
-const ANON_KEY =
-  process.env.SUPABASE_ANON_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
-const SERVICE_ROLE_KEY =
-  process.env.SUPABASE_SERVICE_ROLE_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+// No fallback values on purpose: these must come from the actually-running local stack
+// (`supabase status -o env`), never a literal string committed to the repo, even a
+// non-secret local-dev default. Missing env fails the whole file loudly instead of
+// silently running against a guessed value.
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Run \`supabase start\`, then export its output ` +
+        "(see CLAUDE.md's Local development section) before running these tests.",
+    );
+  }
+  return value;
+}
+
+const SUPABASE_URL = requireEnv("SUPABASE_URL");
+const ANON_KEY = requireEnv("SUPABASE_ANON_KEY");
+const SERVICE_ROLE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
 
 interface AnonSession {
   client: SupabaseClient;

--- a/packages/supabase-tests/src/games-rls.test.ts
+++ b/packages/supabase-tests/src/games-rls.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// Fixed local-dev demo keys - identical for every fresh `supabase init` project using the
+// default JWT secret, not a real secret. Overridable via env for a non-default local stack.
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+interface AnonSession {
+  client: SupabaseClient;
+  userId: string;
+}
+
+async function signInAnonymously(): Promise<AnonSession> {
+  const client = createClient(SUPABASE_URL, ANON_KEY);
+  const { data, error } = await client.auth.signInAnonymously();
+  if (error || !data.user) {
+    throw error ?? new Error("anonymous sign-in returned no user");
+  }
+  return { client, userId: data.user.id };
+}
+
+const serviceClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+describe("games RLS + grants", () => {
+  it("gates reads/writes across host, invited participant, and an uninvolved third party", async () => {
+    const host = await signInAnonymously();
+    const visitor = await signInAnonymously();
+    const stranger = await signInAnonymously();
+
+    const created = await serviceClient
+      .from("games")
+      .insert({ host_user_id: host.userId, game_state: {} })
+      .select()
+      .single();
+    expect(created.error).toBeNull();
+    const gameId = created.data!.id as string;
+
+    const hostRead = await host.client.from("games").select().eq("id", gameId);
+    expect(hostRead.data).toHaveLength(1);
+
+    const openInviteRead = await visitor.client.from("games").select().eq("id", gameId);
+    expect(openInviteRead.data).toHaveLength(1);
+
+    const directJoinAttempt = await visitor.client
+      .from("games")
+      .update({ invited_user_id: visitor.userId })
+      .eq("id", gameId);
+    expect(directJoinAttempt.error?.code).toBe("42501");
+
+    const join = await serviceClient
+      .from("games")
+      .update({ invited_user_id: visitor.userId })
+      .eq("id", gameId);
+    expect(join.error).toBeNull();
+
+    const strangerReadAfterClose = await stranger.client.from("games").select().eq("id", gameId);
+    expect(strangerReadAfterClose.data).toHaveLength(0);
+
+    const participantRead = await visitor.client.from("games").select().eq("id", gameId);
+    expect(participantRead.data).toHaveLength(1);
+
+    const directMoveAttempt = await visitor.client
+      .from("games")
+      .update({ game_state: { hacked: true } })
+      .eq("id", gameId);
+    expect(directMoveAttempt.error?.code).toBe("42501");
+  });
+
+  it("lets a participant list their own games without seeing strangers' open lobbies", async () => {
+    const me = await signInAnonymously();
+    const someoneElse = await signInAnonymously();
+
+    const mine = await serviceClient
+      .from("games")
+      .insert({ host_user_id: me.userId, game_state: {} })
+      .select()
+      .single();
+    expect(mine.error).toBeNull();
+
+    const theirsOpen = await serviceClient
+      .from("games")
+      .insert({ host_user_id: someoneElse.userId, game_state: {} })
+      .select()
+      .single();
+    expect(theirsOpen.error).toBeNull();
+
+    const myGames = await me.client
+      .from("games")
+      .select()
+      .or(`host_user_id.eq.${me.userId},invited_user_id.eq.${me.userId}`);
+
+    expect(myGames.data?.map((g) => g.id)).toContain(mine.data!.id);
+    expect(myGames.data?.map((g) => g.id)).not.toContain(theirsOpen.data!.id);
+  });
+});

--- a/packages/supabase-tests/tsconfig.json
+++ b/packages/supabase-tests/tsconfig.json
@@ -4,13 +4,11 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src",
+    "noEmit": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,23 @@ importers:
         version: 6.0.3
       vitest:
         specifier: latest
-        version: 4.1.9(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2))
+        version: 4.1.9(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0))
+
+  packages/supabase-tests:
+    dependencies:
+      '@supabase/supabase-js':
+        specifier: latest
+        version: 2.110.0
+    devDependencies:
+      '@types/node':
+        specifier: latest
+        version: 26.1.0
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: latest
+        version: 4.1.9(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0))
 
 packages:
 
@@ -294,6 +310,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.110.0':
+    resolution: {integrity: sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/functions-js@2.110.0':
+    resolution: {integrity: sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+
+  '@supabase/postgrest-js@2.110.0':
+    resolution: {integrity: sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/realtime-js@2.110.0':
+    resolution: {integrity: sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/storage-js@2.110.0':
+    resolution: {integrity: sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/supabase-js@2.110.0':
+    resolution: {integrity: sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==}
+    engines: {node: '>=22.0.0'}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -308,6 +351,9 @@ packages:
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -400,6 +446,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -569,6 +619,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -798,6 +851,38 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.110.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.110.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.4': {}
+
+  '@supabase/postgrest-js@2.110.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.110.0':
+    dependencies:
+      '@supabase/phoenix': 0.4.4
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.110.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.110.0':
+    dependencies:
+      '@supabase/auth-js': 2.110.0
+      '@supabase/functions-js': 2.110.0
+      '@supabase/postgrest-js': 2.110.0
+      '@supabase/realtime-js': 2.110.0
+      '@supabase/storage-js': 2.110.0
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -815,6 +900,10 @@ snapshots:
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/node@26.1.0':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -838,13 +927,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@24.13.2))':
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@26.1.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@24.13.2)
+      vite: 8.1.3(@types/node@26.1.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -894,6 +983,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  iceberg-js@0.8.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1035,12 +1126,13 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   typescript@6.0.3: {}
 
   undici-types@7.18.2: {}
+
+  undici-types@8.3.0: {}
 
   vite@8.1.3(@types/node@24.13.2):
     dependencies:
@@ -1053,10 +1145,21 @@ snapshots:
       '@types/node': 24.13.2
       fsevents: 2.3.3
 
-  vitest@4.1.9(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)):
+  vite@8.1.3(@types/node@26.1.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.0
+      fsevents: 2.3.3
+
+  vitest@4.1.9(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@24.13.2))
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@26.1.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -1073,10 +1176,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@24.13.2)
+      vite: 8.1.3(@types/node@26.1.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
     transitivePeerDependencies:
       - msw
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -175,7 +175,7 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
@@ -386,7 +386,7 @@ deno_version = 2
 # secret_key = "env(SECRET_VALUE)"
 
 [analytics]
-enabled = true
+enabled = false
 port = 54327
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"

--- a/supabase/migrations/20260704220000_games_schema.sql
+++ b/supabase/migrations/20260704220000_games_schema.sql
@@ -1,0 +1,54 @@
+-- games table replaces the legacy `users` + `games` (with host_token/invited_token) design.
+-- Identity is now Supabase Auth (auth.users, including anonymous sessions); access control is
+-- enforced by RLS instead of comparing a client-supplied token string in application code.
+
+create table public.games (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  host_user_id uuid not null references auth.users (id) on delete cascade,
+  invited_user_id uuid references auth.users (id) on delete set null,
+  game_state jsonb not null
+);
+
+create index games_host_user_id_idx on public.games (host_user_id);
+create index games_invited_user_id_idx on public.games (invited_user_id);
+
+create function public.set_games_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger games_set_updated_at
+  before update on public.games
+  for each row
+  execute function public.set_games_updated_at();
+
+-- Table-level GRANTs are required in addition to RLS: Supabase no longer auto-exposes new public
+-- tables to the API roles (see `auto_expose_new_tables` in supabase/config.toml), so without these
+-- every request gets "permission denied for table games" before RLS even runs. `service_role`
+-- bypasses RLS but still needs standard privileges to read/write at all.
+grant select on public.games to authenticated;
+grant select, insert, update, delete on public.games to service_role;
+
+alter table public.games enable row level security;
+
+-- A row is readable by its host, its invited participant, or anyone (while it's still open,
+-- i.e. invited_user_id is null) so a visitor can load the game to join it via the invite link.
+create policy "Participants and open invites can read games"
+  on public.games for select
+  to authenticated
+  using (
+    host_user_id = (select auth.uid())
+    or invited_user_id = (select auth.uid())
+    or invited_user_id is null
+  );
+
+-- No insert/update/delete policy is defined for `authenticated`, so RLS denies all direct client
+-- writes by default. All mutations (create-game, join-game, make-move) go through Edge Functions
+-- using the service-role key, which bypasses RLS but is still subject to the GRANTs above.


### PR DESCRIPTION
Closes #4.

**Schema & RLS** (`supabase/migrations/20260704220000_games_schema.sql`):
- `games` table: `id, created_at, updated_at, host_user_id -> auth.users, invited_user_id -> auth.users (nullable), game_state jsonb`, plus an `updated_at` trigger.
- RLS enabled with one SELECT policy: readable by the host, the invited participant, or anyone while `invited_user_id IS NULL` (open invite link).
- Explicit `GRANT`s for `authenticated`/`service_role` — Supabase no longer auto-exposes new tables to the API roles, so without these every request 403s before RLS even runs. Found this by actually testing against a live stack rather than just reading the policy SQL.
- Anonymous auth enabled in `supabase/config.toml`.
- Drops the legacy `users` table and `host_token`/`invited_token` columns entirely.

**Local dev** (`docker-compose.yml` + `apps/web/Dockerfile.dev`, per discussion on this issue):
- Runs `apps/web` in a dev container (hot reload via bind mount) pointed at the local Supabase stack via `host.docker.internal`.
- The Supabase stack itself stays owned by `supabase start` rather than reimplemented in compose — see the "Local development" section added to CLAUDE.md for the reasoning (it's ~10 CLI-managed services, version-locked and migration-aware; hand-copying it would just be a second stack to keep in sync).
- `pnpm dev:full` chains `supabase start && docker compose up --build` into one command.
- Also disabled the local analytics/Logflare service (`config.toml`) — it fails health checks on Windows/Docker Desktop without extra config and was taking the *entire* local stack down with it (spent a while chasing this).

**Verification performed** (against a live local stack, not just inference from the SQL):
- `supabase db reset` applies the migration cleanly.
- Three distinct anonymous sessions (host, invited participant, uninvolved third party) exercised via raw REST calls: host and open-invite reads succeed, direct client writes are hard-denied (`permission denied`, not just silently filtered), the invite window correctly closes once claimed (third party loses read access), and the invited participant can read but still can't write `game_state` directly.
- `docker compose build/up` for `web` succeeds, page is reachable on `localhost:5173`, env vars reach the container, and a live source edit hot-reloaded through the Windows→Docker bind mount.

Per the process in CLAUDE.md, I'll wait for review/merge before starting issue #5 (game engine TypeScript port).