### PR TITLE
Add Supabase Edge Functions: create-game, join-game, make-move

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,35 @@ jobs:
       - run: pnpm --filter web lint
       - run: pnpm --filter web build
 
+  edge-functions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - run: pnpm install --frozen-lockfile
+
+      # The functions import packages/game-engine/dist (built output), not its src - Deno
+      # doesn't resolve that package's .js-specifier-pointing-at-.ts-sibling source layout
+      # (fine for Node/Vite's "Bundler" resolution, not for plain Deno), and the deployed
+      # edge-runtime can't be pointed at src either. See supabase/functions/_shared/gameRow.ts.
+      - run: pnpm --filter @mintactoe/game-engine build
+
+      # --config is explicit because Deno's config auto-discovery walks up from the cwd (repo
+      # root here) and would otherwise stop at the root package.json/pnpm-workspace.yaml
+      # instead of finding supabase/functions/deno.json.
+      - run: deno test --allow-env --allow-net --config supabase/functions/deno.json supabase/functions
+
   supabase:
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +101,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # The local Edge Runtime (started below) serves supabase/functions, which import
+      # packages/game-engine/dist - it must exist on disk before `supabase start` boots them.
+      - run: pnpm --filter @mintactoe/game-engine build
+
       - run: supabase start
 
       # Only runs on a cache miss (first run, or the CLI version bumped and pulled different
@@ -87,6 +120,21 @@ jobs:
           echo "SUPABASE_URL=$API_URL" >> "$GITHUB_ENV"
           echo "SUPABASE_ANON_KEY=$ANON_KEY" >> "$GITHUB_ENV"
           echo "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY" >> "$GITHUB_ENV"
+
+      # `supabase start` already boots the local Edge Runtime and serves whatever it finds
+      # under supabase/functions (config.toml's [edge_runtime] block) - this just confirms
+      # that happened, so a serving failure here fails fast with a clear message instead of
+      # a cryptic fetch error buried in the vitest run below.
+      - name: Wait for local Edge Functions to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null -X OPTIONS -H "apikey: $SUPABASE_ANON_KEY" "$SUPABASE_URL/functions/v1/create-game"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Edge Functions did not become ready in time"
+          exit 1
 
       - run: pnpm --filter @mintactoe/supabase-tests lint
       - run: pnpm --filter @mintactoe/supabase-tests test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ supabase/
   config.toml           Local dev + project config
   migrations/            SQL schema + RLS policies — the source of truth for the DB
   functions/
+    deno.json              Shared Deno config for all functions (test file discovery, see below)
+    _shared/                Auth/error/response helpers + game-row typing shared by all three functions
     create-game/
     join-game/
     make-move/
@@ -60,16 +62,21 @@ One command runs the full new stack locally (Supabase + frontend) against each o
 pnpm dev:full
 ```
 
-This just chains `supabase start && docker compose up --build` (see root `package.json`). Equivalent manual steps:
+This just chains `pnpm --filter @mintactoe/game-engine build && supabase start && docker compose up --build` (see root `package.json`). Equivalent manual steps:
 
 ```
-supabase start                          # starts the local Supabase stack (Postgres/Auth/Realtime/Studio),
-                                         # applying supabase/migrations/ automatically
+pnpm --filter @mintactoe/game-engine build   # builds packages/game-engine/dist - supabase/functions/*
+                                              # import from there (not src), and must exist before the
+                                              # next step or the local Edge Runtime fails to boot them
+supabase start                          # starts the local Supabase stack (Postgres/Auth/Realtime/Studio/
+                                         # Edge Functions), applying supabase/migrations/ automatically
 supabase status                         # shows the local anon key and API URL
 cp .env.example .env                    # then fill in VITE_SUPABASE_ANON_KEY from the above (one-time)
 docker compose up                       # builds and runs apps/web in a dev container with hot reload,
                                          # pointed at the local Supabase stack via host.docker.internal
 ```
+
+If you edit `packages/game-engine` while a local stack is already running, re-run the build and then `supabase stop && supabase start` - the local Edge Runtime doesn't pick up dist changes made after it started.
 
 The Supabase stack itself is run via `supabase start`, not reimplemented in `docker-compose.yml` — the Supabase CLI already manages its own docker compose stack, version-matched to `supabase/config.toml`, with migrations auto-applied and a Studio UI. `docker-compose.yml` at the repo root only wraps `apps/web`, so the whole app can be exercised end-to-end (including from a phone/another device on the same network, or without a local Node install) without hand-wiring the Supabase containers ourselves.
 
@@ -86,5 +93,8 @@ Running the frontend natively instead of in Docker also works: `pnpm --filter we
     pnpm --filter @mintactoe/supabase-tests test
     ```
     CI does the equivalent itself as a step, after `supabase start`.
-- `supabase/functions/*` (once they exist): unit-test the orchestration logic with a mocked Supabase client; extend `packages/supabase-tests` (or a similar suite) to integration-test the deployed functions against the real local stack.
+- `supabase/functions/*`: each function is a thin `index.ts` (`Deno.serve`, extracts the caller from the JWT via `_shared/auth.ts`, calls the handler, maps errors to HTTP status) delegating to an exported `handler.ts` orchestration function that takes a `SupabaseClient` as a parameter — that's what makes it unit-testable without booting the serve loop. Unit tests (`handler.test.ts`, Deno's built-in test runner, not Vitest — this code runs on Deno, not Node) use `_shared/testSupabase.ts`, a minimal fluent fake of the `.from("games")...` chain that hands back scripted `{ data, error }` results in call order, rather than a full Postgrest mock. Run with `deno test --allow-env --allow-net --config supabase/functions/deno.json supabase/functions` (the explicit `--config` matters: Deno's auto-discovery walks up from the cwd and stops at the root `package.json`/`pnpm-workspace.yaml` instead of finding this one).
+  - **These functions import `packages/game-engine/dist` (built output), not `src`.** That package's own internal imports use the `./foo.js`-pointing-at-`./foo.ts` convention (valid under its `tsconfig.json`'s `"moduleResolution": "Bundler"`, for Node/Vite consumers) — plain Deno's module graph resolution can't follow that, and critically, the *deployed* `supabase-edge-runtime` (unlike the plain `deno` CLI) doesn't support the `sloppy-imports` flag that would otherwise paper over it, so pointing at `src` breaks the function's actual boot, not just local type-checking. Run `pnpm --filter @mintactoe/game-engine build` before `supabase start` or `deno test`/`deno check` against this directory (see "Local development" above); CI does this in both the `edge-functions` and `supabase` jobs.
+  - **The `Player`/`Coordinate`/`Rules`/`SerializedGame` types are mirrored locally in `_shared/gameRow.ts`**, not imported from `packages/game-engine`, even though the values (`initialize`, `serializeGame`, `deserializeGame`, `makeMove`, the `*Error` classes) are imported normally from `dist/index.js`. Deno's checker infers value types loosely straight from the plain compiled JS but doesn't resolve a `type`-only export re-exported through a `.js` specifier back to its real declaration — and, as above, it can't be pointed at `src` either. These types are small and frozen (see `docs/game-rules.md`), so the duplication is a deliberate, documented trade-off, not an oversight.
+  - Integration tests live in `packages/supabase-tests/src/edge-functions.test.ts` (Vitest, real `fetch` calls to `${SUPABASE_URL}/functions/v1/<name>` with real anonymous-session bearer tokens) — `supabase start` serves local functions automatically (config.toml's `[edge_runtime]` block), no separate `supabase functions serve` needed for CI/testing purposes.
 - `apps/web`: component tests (Vitest + React Testing Library) plus Playwright e2e for the full online flow (two browser contexts playing a real game against the local Supabase stack).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter web dev",
-    "dev:full": "supabase start && docker compose up --build",
+    "dev:full": "pnpm --filter @mintactoe/game-engine build && supabase start && docker compose up --build",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint"

--- a/packages/supabase-tests/src/edge-functions.test.ts
+++ b/packages/supabase-tests/src/edge-functions.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { SUPABASE_URL, SUPABASE_ANON_KEY, signInAnonymously, type AnonSession } from "./testEnv.js";
+
+interface FunctionResponse {
+  status: number;
+  body: any;
+}
+
+async function callFunction(name: string, session: AnonSession, body: unknown = {}): Promise<FunctionResponse> {
+  const response = await fetch(`${SUPABASE_URL}/functions/v1/${name}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      apikey: SUPABASE_ANON_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+describe("Edge Functions (create-game, join-game, make-move)", () => {
+  it("create-game is idempotent per caller and returns an unfinished game on repeat calls", async () => {
+    const host = await signInAnonymously();
+
+    const first = await callFunction("create-game", host);
+    expect(first.status).toBe(200);
+    expect(first.body.game.host_user_id).toBe(host.userId);
+    expect(first.body.game.invited_user_id).toBeNull();
+    expect(first.body.game.game_state.gameState.isGameOver).toBe(false);
+
+    const second = await callFunction("create-game", host);
+    expect(second.status).toBe(200);
+    expect(second.body.game.id).toBe(first.body.game.id);
+  });
+
+  it("join-game rejects the host joining their own game, then lets a visitor join, then rejects a third player", async () => {
+    const host = await signInAnonymously();
+    const visitor = await signInAnonymously();
+    const stranger = await signInAnonymously();
+
+    const created = await callFunction("create-game", host);
+    const gameId = created.body.game.id as string;
+
+    const selfJoin = await callFunction("join-game", host, { gameId });
+    expect(selfJoin.status).toBe(409);
+
+    const join = await callFunction("join-game", visitor, { gameId });
+    expect(join.status).toBe(200);
+    expect(join.body.game.invited_user_id).toBe(visitor.userId);
+
+    const full = await callFunction("join-game", stranger, { gameId });
+    expect(full.status).toBe(409);
+  });
+
+  it("make-move rejects non-participants and malformed coordinates, then enforces turn order across a real move", async () => {
+    const host = await signInAnonymously();
+    const visitor = await signInAnonymously();
+    const stranger = await signInAnonymously();
+
+    const created = await callFunction("create-game", host);
+    const gameId = created.body.game.id as string;
+    await callFunction("join-game", visitor, { gameId });
+
+    const byStranger = await callFunction("make-move", stranger, { gameId, coordinate: { row: 0, col: 0 } });
+    expect(byStranger.status).toBe(403);
+
+    const malformed = await callFunction("make-move", host, { gameId, coordinate: { row: "0", col: 0 } });
+    expect(malformed.status).toBe(400);
+
+    const hostMove = await callFunction("make-move", host, { gameId, coordinate: { row: 0, col: 0 } });
+    expect(hostMove.status).toBe(200);
+    expect(hostMove.body.game.game_state.gameState.movesPlayed).toBe(1);
+
+    const hostMovesAgain = await callFunction("make-move", host, { gameId, coordinate: { row: 1, col: 1 } });
+    expect(hostMovesAgain.status).toBe(400);
+    expect(hostMovesAgain.body.error).toBe("NotYourTurnError");
+
+    const visitorMove = await callFunction("make-move", visitor, { gameId, coordinate: { row: 1, col: 1 } });
+    expect(visitorMove.status).toBe(200);
+    expect(visitorMove.body.game.game_state.gameState.movesPlayed).toBe(2);
+  });
+
+  it("rejects a make-move on a game the caller was never invited to", async () => {
+    const host = await signInAnonymously();
+    const stranger = await signInAnonymously();
+
+    const created = await callFunction("create-game", host);
+    const gameId = created.body.game.id as string;
+
+    const result = await callFunction("make-move", stranger, { gameId, coordinate: { row: 0, col: 0 } });
+    expect(result.status).toBe(403);
+  });
+});

--- a/packages/supabase-tests/src/games-rls.test.ts
+++ b/packages/supabase-tests/src/games-rls.test.ts
@@ -1,40 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-
-// No fallback values on purpose: these must come from the actually-running local stack
-// (`supabase status -o env`), never a literal string committed to the repo, even a
-// non-secret local-dev default. Missing env fails the whole file loudly instead of
-// silently running against a guessed value.
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(
-      `${name} is not set. Run \`supabase start\`, then export its output ` +
-        "(see CLAUDE.md's Local development section) before running these tests.",
-    );
-  }
-  return value;
-}
-
-const SUPABASE_URL = requireEnv("SUPABASE_URL");
-const ANON_KEY = requireEnv("SUPABASE_ANON_KEY");
-const SERVICE_ROLE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
-
-interface AnonSession {
-  client: SupabaseClient;
-  userId: string;
-}
-
-async function signInAnonymously(): Promise<AnonSession> {
-  const client = createClient(SUPABASE_URL, ANON_KEY);
-  const { data, error } = await client.auth.signInAnonymously();
-  if (error || !data.user) {
-    throw error ?? new Error("anonymous sign-in returned no user");
-  }
-  return { client, userId: data.user.id };
-}
-
-const serviceClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+import { serviceClient, signInAnonymously } from "./testEnv.js";
 
 describe("games RLS + grants", () => {
   it("gates reads/writes across host, invited participant, and an uninvolved third party", async () => {

--- a/packages/supabase-tests/src/testEnv.ts
+++ b/packages/supabase-tests/src/testEnv.ts
@@ -1,0 +1,37 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// No fallback values on purpose: these must come from the actually-running local stack
+// (`supabase status -o env`), never a literal string committed to the repo, even a
+// non-secret local-dev default. Missing env fails the whole file loudly instead of
+// silently running against a guessed value.
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Run \`supabase start\`, then export its output ` +
+        "(see CLAUDE.md's Local development section) before running these tests.",
+    );
+  }
+  return value;
+}
+
+export const SUPABASE_URL = requireEnv("SUPABASE_URL");
+export const SUPABASE_ANON_KEY = requireEnv("SUPABASE_ANON_KEY");
+export const SUPABASE_SERVICE_ROLE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+export interface AnonSession {
+  client: SupabaseClient;
+  userId: string;
+  accessToken: string;
+}
+
+export async function signInAnonymously(): Promise<AnonSession> {
+  const client = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const { data, error } = await client.auth.signInAnonymously();
+  if (error || !data.user || !data.session) {
+    throw error ?? new Error("anonymous sign-in returned no user/session");
+  }
+  return { client, userId: data.user.id, accessToken: data.session.access_token };
+}
+
+export const serviceClient: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -385,6 +385,19 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# All three functions authenticate the caller themselves (see supabase/functions/_shared/auth.ts)
+# and write via the service-role client, bypassing RLS by design (see
+# supabase/migrations/20260704220000_games_schema.sql) - verify_jwt must stay on so the platform
+# rejects unauthenticated requests before they even reach the handler.
+[functions.create-game]
+verify_jwt = true
+
+[functions.join-game]
+verify_jwt = true
+
+[functions.make-move]
+verify_jwt = true
+
 [analytics]
 enabled = false
 port = 54327

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,27 @@
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { UnauthenticatedError } from "./errors.ts";
+
+// Resolves the calling `auth.uid()` from the request's bearer token by asking GoTrue to
+// verify it (rather than decoding the JWT payload ourselves) so this stays correct even if
+// per-function `verify_jwt` config ever changes - it doesn't rely on the gateway having
+// already checked the signature.
+export async function getCallerId(req: Request): Promise<string> {
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!token) {
+    throw new UnauthenticatedError("Missing Authorization bearer token.");
+  }
+
+  const url = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!url || !anonKey) {
+    throw new Error("SUPABASE_URL and SUPABASE_ANON_KEY must be set.");
+  }
+
+  const authClient = createClient(url, anonKey);
+  const { data, error } = await authClient.auth.getUser(token);
+  if (error || !data.user) {
+    throw new UnauthenticatedError("Invalid or expired token.");
+  }
+  return data.user.id;
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,6 @@
+// The frontend (apps/web, issue #7/#8) calls these functions directly from the browser,
+// so preflight OPTIONS requests need a response and actual responses need these headers.
+export const corsHeaders: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};

--- a/supabase/functions/_shared/errors.ts
+++ b/supabase/functions/_shared/errors.ts
@@ -1,0 +1,45 @@
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = new.target.name;
+    this.status = status;
+  }
+}
+
+export class UnauthenticatedError extends HttpError {
+  constructor(message = "Missing or invalid credentials.") {
+    super(401, message);
+  }
+}
+
+export class InvalidRequestError extends HttpError {
+  constructor(message: string) {
+    super(400, message);
+  }
+}
+
+export class GameNotFoundError extends HttpError {
+  constructor(gameId: string) {
+    super(404, `Game ${gameId} not found.`);
+  }
+}
+
+export class NotAParticipantError extends HttpError {
+  constructor() {
+    super(403, "You are not a participant in this game.");
+  }
+}
+
+export class CannotJoinOwnGameError extends HttpError {
+  constructor() {
+    super(409, "You cannot join a game you are hosting.");
+  }
+}
+
+export class GameAlreadyFullError extends HttpError {
+  constructor() {
+    super(409, "This game already has two players.");
+  }
+}

--- a/supabase/functions/_shared/gameRow.ts
+++ b/supabase/functions/_shared/gameRow.ts
@@ -1,0 +1,56 @@
+// These mirror packages/game-engine/src/types.ts and serialization.ts exactly (the wire
+// format is frozen - see docs/game-rules.md) rather than importing them from there: Deno's
+// checker can't resolve a `type`-only export re-exported through a .js specifier back to its
+// real declaration (it infers loosely from the plain compiled JS instead), and the deployed
+// edge-runtime can't resolve packages/game-engine/src directly - it graph-walks every import
+// regardless of the `type` keyword, and that source uses .js-specifiers pointing at sibling
+// .ts files (fine for Node/Vite's "Bundler" resolution, not for plain Deno). Only
+// packages/game-engine/dist's compiled value exports cross that boundary cleanly (see
+// supabase/functions/deno.json and the handler.ts files that import from dist/index.js).
+export type Player = "O" | "X";
+
+export interface Coordinate {
+  row: number;
+  col: number;
+}
+
+export interface Field {
+  player: Player | null;
+  surroundedByNotExplodedMines: number;
+  isMine: boolean;
+  generated: boolean;
+  hasAllNeighboursGenerated: boolean;
+}
+
+export interface Rules {
+  rows: number;
+  columns: number;
+  seriesLength: number;
+  noMineMoves: number;
+  minePower: number;
+  mineProbability: number;
+}
+
+export interface SerializedGame {
+  rules: Rules;
+  gameState: {
+    grid: Record<string, Field>;
+    isGameOver: boolean;
+    winner: Player | null;
+    playerOnTurn: Player | null;
+    changes: Coordinate[];
+    movesPlayed: number;
+  };
+}
+
+// Shape of a row in `public.games` (see supabase/migrations/20260704220000_games_schema.sql).
+export interface GameRow {
+  id: string;
+  host_user_id: string;
+  invited_user_id: string | null;
+  game_state: SerializedGame;
+}
+
+export function isUnfinished(row: GameRow): boolean {
+  return row.game_state.gameState.isGameOver === false;
+}

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,24 @@
+import { MinTacToeError } from "../../../packages/game-engine/dist/index.js";
+import { corsHeaders } from "./cors.ts";
+import { HttpError } from "./errors.ts";
+
+export function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+// Maps both our own orchestration errors (HttpError) and game-engine validation errors
+// (MinTacToeError, e.g. NotYourTurnError) to a 400/other client error response; anything
+// else is unexpected and comes back as a 500 without leaking internal details.
+export function errorResponse(error: unknown): Response {
+  if (error instanceof HttpError) {
+    return json({ error: error.name, message: error.message }, error.status);
+  }
+  if (error instanceof MinTacToeError) {
+    return json({ error: error.name, message: error.message }, 400);
+  }
+  console.error(error);
+  return json({ error: "InternalError", message: "Something went wrong." }, 500);
+}

--- a/supabase/functions/_shared/supabaseAdmin.ts
+++ b/supabase/functions/_shared/supabaseAdmin.ts
@@ -1,0 +1,14 @@
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+// SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are provided automatically by the Edge Functions
+// runtime (both locally via `supabase start`/`functions serve` and when deployed) - no secrets
+// setup needed. This client bypasses RLS, which is exactly why writes to `games` only happen
+// through these functions (see supabase/migrations/20260704220000_games_schema.sql).
+export function createAdminClient(): SupabaseClient {
+  const url = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !serviceRoleKey) {
+    throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.");
+  }
+  return createClient(url, serviceRoleKey, { auth: { persistSession: false } });
+}

--- a/supabase/functions/_shared/testSupabase.ts
+++ b/supabase/functions/_shared/testSupabase.ts
@@ -1,0 +1,66 @@
+import type { GameRow } from "./gameRow.ts";
+
+export interface MockResult<T = unknown> {
+  data: T | null;
+  error: { message: string } | null;
+}
+
+function chainable(result: MockResult): unknown {
+  const builder = {
+    select: () => builder,
+    insert: () => builder,
+    update: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    single: () => builder,
+    maybeSingle: () => builder,
+    then: (onFulfilled: (r: MockResult) => unknown, onRejected?: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(onFulfilled, onRejected),
+  };
+  return builder;
+}
+
+/**
+ * Fakes just the `.from("games")...` entry point of a SupabaseClient. Each handler under
+ * test makes a fixed, known sequence of `.from()` calls, so this hands back scripted
+ * results in that call order rather than modelling real Postgrest filter/chain semantics.
+ */
+export function createMockSupabase(results: MockResult[]): unknown {
+  const queue = [...results];
+  return {
+    from: () => {
+      const result = queue.shift();
+      if (!result) {
+        throw new Error("createMockSupabase: ran out of scripted results");
+      }
+      return chainable(result);
+    },
+  };
+}
+
+export function createGameRow(overrides: Partial<GameRow> = {}): GameRow {
+  return {
+    id: "game-1",
+    host_user_id: "host-1",
+    invited_user_id: null,
+    game_state: {
+      rules: {
+        rows: 16,
+        columns: 16,
+        seriesLength: 5,
+        noMineMoves: 6,
+        minePower: 1,
+        mineProbability: 0.1,
+      },
+      gameState: {
+        grid: {},
+        isGameOver: false,
+        winner: null,
+        playerOnTurn: "O",
+        changes: [],
+        movesPlayed: 0,
+      },
+    },
+    ...overrides,
+  };
+}

--- a/supabase/functions/create-game/handler.test.ts
+++ b/supabase/functions/create-game/handler.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertNotEquals } from "jsr:@std/assert@1";
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { createGameRow, createMockSupabase } from "../_shared/testSupabase.ts";
+import { createGame } from "./handler.ts";
+
+Deno.test("createGame - inserts a new game when the caller hosts none", async () => {
+  const inserted = createGameRow({ id: "new-game" });
+  const supabase = createMockSupabase([
+    { data: [], error: null }, // lookup for an existing unfinished game
+    { data: inserted, error: null }, // insert
+  ]) as unknown as SupabaseClient;
+
+  const result = await createGame(supabase, { callerId: "host-1" });
+
+  assertEquals(result.id, "new-game");
+});
+
+Deno.test("createGame - returns the caller's existing unfinished game instead of inserting", async () => {
+  const existing = createGameRow({ id: "existing-game" });
+  const supabase = createMockSupabase([
+    { data: [existing], error: null },
+  ]) as unknown as SupabaseClient;
+
+  const result = await createGame(supabase, { callerId: "host-1" });
+
+  assertEquals(result.id, "existing-game");
+});
+
+Deno.test("createGame - ignores the caller's finished games and creates a new one", async () => {
+  const finished = createGameRow({ id: "finished-game" });
+  finished.game_state.gameState.isGameOver = true;
+  const inserted = createGameRow({ id: "new-game" });
+
+  const supabase = createMockSupabase([
+    { data: [finished], error: null },
+    { data: inserted, error: null },
+  ]) as unknown as SupabaseClient;
+
+  const result = await createGame(supabase, { callerId: "host-1" });
+
+  assertEquals(result.id, "new-game");
+  assertNotEquals(result.id, "finished-game");
+});

--- a/supabase/functions/create-game/handler.ts
+++ b/supabase/functions/create-game/handler.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { initialize, serializeGame } from "../../../packages/game-engine/dist/index.js";
+import { isUnfinished, type GameRow, type Rules } from "../_shared/gameRow.ts";
+
+// docs/game-rules.md: production games override the engine's defaults to a 16x16 board.
+// This is a caller concern, not an engine default, so it's applied here rather than in
+// packages/game-engine.
+export const PRODUCTION_RULES: Partial<Rules> = { rows: 16, columns: 16 };
+
+export interface CreateGameParams {
+  callerId: string;
+}
+
+/**
+ * Idempotent per caller: if `callerId` already hosts an unfinished game, that row is
+ * returned instead of inserting a new one. This both caps create-spam from one session
+ * (issue #9) and doubles as the "resume my game" mechanism (issue #6/#7).
+ */
+export async function createGame(
+  supabase: SupabaseClient,
+  params: CreateGameParams,
+): Promise<GameRow> {
+  const { data: existingRows, error: fetchError } = await supabase
+    .from("games")
+    .select("*")
+    .eq("host_user_id", params.callerId)
+    .order("created_at", { ascending: false });
+
+  if (fetchError) {
+    throw fetchError;
+  }
+
+  const existing = (existingRows as GameRow[] | null)?.find(isUnfinished);
+  if (existing) {
+    return existing;
+  }
+
+  const serialized = serializeGame(initialize(PRODUCTION_RULES));
+
+  const { data: inserted, error: insertError } = await supabase
+    .from("games")
+    .insert({ host_user_id: params.callerId, game_state: serialized })
+    .select("*")
+    .single();
+
+  if (insertError) {
+    throw insertError;
+  }
+  return inserted as GameRow;
+}

--- a/supabase/functions/create-game/index.ts
+++ b/supabase/functions/create-game/index.ts
@@ -1,0 +1,19 @@
+import { getCallerId } from "../_shared/auth.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import { errorResponse, json } from "../_shared/http.ts";
+import { createAdminClient } from "../_shared/supabaseAdmin.ts";
+import { createGame } from "./handler.ts";
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const callerId = await getCallerId(req);
+    const game = await createGame(createAdminClient(), { callerId });
+    return json({ game });
+  } catch (error) {
+    return errorResponse(error);
+  }
+});

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "include": ["**/*.test.ts"]
+  }
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,0 +1,72 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "npm:@supabase/supabase-js@2": "2.110.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.110.0": {
+      "integrity": "sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.110.0": {
+      "integrity": "sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    },
+    "@supabase/postgrest-js@2.110.0": {
+      "integrity": "sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.110.0": {
+      "integrity": "sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.110.0": {
+      "integrity": "sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.110.0": {
+      "integrity": "sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  }
+}

--- a/supabase/functions/join-game/handler.test.ts
+++ b/supabase/functions/join-game/handler.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@1";
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+import {
+  CannotJoinOwnGameError,
+  GameAlreadyFullError,
+  GameNotFoundError,
+} from "../_shared/errors.ts";
+import { createGameRow, createMockSupabase } from "../_shared/testSupabase.ts";
+import { joinGame } from "./handler.ts";
+
+Deno.test("joinGame - happy path sets the caller as the invited player", async () => {
+  const open = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: null });
+  const updated = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: "visitor-1" });
+
+  const supabase = createMockSupabase([
+    { data: open, error: null }, // fetch
+    { data: updated, error: null }, // update
+  ]) as unknown as SupabaseClient;
+
+  const result = await joinGame(supabase, { callerId: "visitor-1", gameId: "game-1" });
+
+  assertEquals(result.invited_user_id, "visitor-1");
+});
+
+Deno.test("joinGame - rejects joining a game that already has an invited player", async () => {
+  const full = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: "visitor-1" });
+  const supabase = createMockSupabase([
+    { data: full, error: null },
+  ]) as unknown as SupabaseClient;
+
+  await assertRejects(
+    () => joinGame(supabase, { callerId: "stranger-1", gameId: "game-1" }),
+    GameAlreadyFullError,
+  );
+});
+
+Deno.test("joinGame - rejects the host joining their own game", async () => {
+  const open = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: null });
+  const supabase = createMockSupabase([
+    { data: open, error: null },
+  ]) as unknown as SupabaseClient;
+
+  await assertRejects(
+    () => joinGame(supabase, { callerId: "host-1", gameId: "game-1" }),
+    CannotJoinOwnGameError,
+  );
+});
+
+Deno.test("joinGame - rejects joining a game that doesn't exist", async () => {
+  const supabase = createMockSupabase([
+    { data: null, error: null },
+  ]) as unknown as SupabaseClient;
+
+  await assertRejects(
+    () => joinGame(supabase, { callerId: "visitor-1", gameId: "missing-game" }),
+    GameNotFoundError,
+  );
+});

--- a/supabase/functions/join-game/handler.ts
+++ b/supabase/functions/join-game/handler.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+import {
+  CannotJoinOwnGameError,
+  GameAlreadyFullError,
+  GameNotFoundError,
+  InvalidRequestError,
+} from "../_shared/errors.ts";
+import type { GameRow } from "../_shared/gameRow.ts";
+
+export interface JoinGameParams {
+  callerId: string;
+  gameId: string;
+}
+
+export async function joinGame(supabase: SupabaseClient, params: JoinGameParams): Promise<GameRow> {
+  if (!params.gameId) {
+    throw new InvalidRequestError("gameId is required.");
+  }
+
+  const { data: row, error: fetchError } = await supabase
+    .from("games")
+    .select("*")
+    .eq("id", params.gameId)
+    .maybeSingle();
+
+  if (fetchError) {
+    throw fetchError;
+  }
+  if (!row) {
+    throw new GameNotFoundError(params.gameId);
+  }
+
+  const game = row as GameRow;
+  if (game.host_user_id === params.callerId) {
+    throw new CannotJoinOwnGameError();
+  }
+  if (game.invited_user_id !== null) {
+    throw new GameAlreadyFullError();
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from("games")
+    .update({ invited_user_id: params.callerId })
+    .eq("id", params.gameId)
+    .select("*")
+    .single();
+
+  if (updateError) {
+    throw updateError;
+  }
+  return updated as GameRow;
+}

--- a/supabase/functions/join-game/index.ts
+++ b/supabase/functions/join-game/index.ts
@@ -1,0 +1,20 @@
+import { getCallerId } from "../_shared/auth.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import { errorResponse, json } from "../_shared/http.ts";
+import { createAdminClient } from "../_shared/supabaseAdmin.ts";
+import { joinGame } from "./handler.ts";
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const callerId = await getCallerId(req);
+    const body = await req.json().catch(() => ({}));
+    const game = await joinGame(createAdminClient(), { callerId, gameId: body.gameId });
+    return json({ game });
+  } catch (error) {
+    return errorResponse(error);
+  }
+});

--- a/supabase/functions/make-move/handler.test.ts
+++ b/supabase/functions/make-move/handler.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@1";
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { NotAParticipantError, InvalidRequestError } from "../_shared/errors.ts";
+import { NotYourTurnError } from "../../../packages/game-engine/dist/index.js";
+import { createGameRow, createMockSupabase } from "../_shared/testSupabase.ts";
+import { makeMove } from "./handler.ts";
+
+Deno.test("makeMove - happy path: host (O) moves and the game row is updated", async () => {
+  const game = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: "visitor-1" });
+  const updated = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: "visitor-1" });
+  updated.game_state.gameState.movesPlayed = 1;
+
+  const supabase = createMockSupabase([
+    { data: game, error: null }, // fetch
+    { data: updated, error: null }, // update
+  ]) as unknown as SupabaseClient;
+
+  const result = await makeMove(supabase, {
+    callerId: "host-1",
+    gameId: "game-1",
+    coordinate: { row: 0, col: 0 },
+  });
+
+  assertEquals(result.game_state.gameState.movesPlayed, 1);
+});
+
+Deno.test("makeMove - rejects a move by someone who isn't a participant", async () => {
+  const game = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: "visitor-1" });
+  const supabase = createMockSupabase([
+    { data: game, error: null },
+  ]) as unknown as SupabaseClient;
+
+  await assertRejects(
+    () => makeMove(supabase, { callerId: "stranger-1", gameId: "game-1", coordinate: { row: 0, col: 0 } }),
+    NotAParticipantError,
+  );
+});
+
+Deno.test("makeMove - rejects a move when it isn't the caller's turn", async () => {
+  const game = createGameRow({ id: "game-1", host_user_id: "host-1", invited_user_id: "visitor-1" });
+  game.game_state.gameState.playerOnTurn = "X"; // visitor's turn, not the host's
+
+  const supabase = createMockSupabase([
+    { data: game, error: null },
+  ]) as unknown as SupabaseClient;
+
+  await assertRejects(
+    () => makeMove(supabase, { callerId: "host-1", gameId: "game-1", coordinate: { row: 0, col: 0 } }),
+    NotYourTurnError,
+  );
+});
+
+Deno.test("makeMove - rejects malformed coordinates without touching the database", async () => {
+  const supabase = createMockSupabase([]) as unknown as SupabaseClient;
+
+  await assertRejects(
+    () =>
+      makeMove(supabase, {
+        callerId: "host-1",
+        gameId: "game-1",
+        coordinate: { row: "0", col: 0 },
+      }),
+    InvalidRequestError,
+  );
+});

--- a/supabase/functions/make-move/handler.ts
+++ b/supabase/functions/make-move/handler.ts
@@ -1,0 +1,78 @@
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+import {
+  deserializeGame,
+  makeMove as engineMakeMove,
+  serializeGame,
+} from "../../../packages/game-engine/dist/index.js";
+import { GameNotFoundError, InvalidRequestError, NotAParticipantError } from "../_shared/errors.ts";
+import type { Coordinate, GameRow, Player } from "../_shared/gameRow.ts";
+
+export interface MakeMoveParams {
+  callerId: string;
+  gameId: string;
+  coordinate: unknown;
+}
+
+// The host always plays first as "O" (see docs/game-rules.md); the invited player is "X".
+// This mapping is derived from host_user_id/invited_user_id rather than stored separately.
+function resolvePlayer(game: GameRow, callerId: string): Player {
+  if (game.host_user_id === callerId) {
+    return "O";
+  }
+  if (game.invited_user_id === callerId) {
+    return "X";
+  }
+  throw new NotAParticipantError();
+}
+
+function parseCoordinate(value: unknown): Coordinate {
+  const candidate = value as Partial<Coordinate> | null;
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    !Number.isInteger(candidate.row) ||
+    !Number.isInteger(candidate.col)
+  ) {
+    throw new InvalidRequestError("coordinate must be an object with integer row and col.");
+  }
+  return { row: candidate.row as number, col: candidate.col as number };
+}
+
+export async function makeMove(supabase: SupabaseClient, params: MakeMoveParams): Promise<GameRow> {
+  if (!params.gameId) {
+    throw new InvalidRequestError("gameId is required.");
+  }
+  const coordinate = parseCoordinate(params.coordinate);
+
+  const { data: row, error: fetchError } = await supabase
+    .from("games")
+    .select("*")
+    .eq("id", params.gameId)
+    .maybeSingle();
+
+  if (fetchError) {
+    throw fetchError;
+  }
+  if (!row) {
+    throw new GameNotFoundError(params.gameId);
+  }
+
+  const gameRow = row as GameRow;
+  const player = resolvePlayer(gameRow, params.callerId);
+
+  const game = deserializeGame(gameRow.game_state);
+  engineMakeMove(game, player, coordinate);
+  const serialized = serializeGame(game);
+
+  const { data: updated, error: updateError } = await supabase
+    .from("games")
+    .update({ game_state: serialized })
+    .eq("id", params.gameId)
+    .select("*")
+    .single();
+
+  if (updateError) {
+    throw updateError;
+  }
+  return updated as GameRow;
+}

--- a/supabase/functions/make-move/index.ts
+++ b/supabase/functions/make-move/index.ts
@@ -1,0 +1,24 @@
+import { getCallerId } from "../_shared/auth.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import { errorResponse, json } from "../_shared/http.ts";
+import { createAdminClient } from "../_shared/supabaseAdmin.ts";
+import { makeMove } from "./handler.ts";
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const callerId = await getCallerId(req);
+    const body = await req.json().catch(() => ({}));
+    const game = await makeMove(createAdminClient(), {
+      callerId,
+      gameId: body.gameId,
+      coordinate: body.coordinate,
+    });
+    return json({ game });
+  } catch (error) {
+    return errorResponse(error);
+  }
+});


### PR DESCRIPTION
## Summary
- Closes #6. Implements `supabase/functions/{create-game,join-game,make-move}`, each a thin `index.ts` (JWT → `auth.uid()`, error → HTTP status) delegating to an exported, dependency-injected `handler.ts` orchestration function per the issue's testability requirement.
- `create-game` is idempotent per caller (returns the existing unfinished game instead of inserting) and applies the 16×16 production rules override; this also doubles as the "resume my game" mechanism.
- `join-game` rejects self-joins and already-full games; `make-move` resolves host→`O`/invited→`X`, validates coordinate shape, and delegates all rule enforcement to `packages/game-engine`.
- Unit tests (Deno's test runner) cover every scenario called out in the issue: happy paths, join-when-full, move-when-not-your-turn, move-by-non-participant, malformed coordinates, and create-game idempotency.
- New `packages/supabase-tests/src/edge-functions.test.ts` integration suite hits the real deployed functions over `fetch` with real anonymous sessions; factored the duplicated env/sign-in setup out of the existing RLS test into `testEnv.ts`.
- CI: new `edge-functions` job runs `deno test`; the `supabase` job builds `packages/game-engine` first and waits for the local Edge Runtime to be ready before running the (now expanded) integration suite.

## Design notes (validated by actually running this locally, not just written from docs)
- The functions import `packages/game-engine`'s **built `dist` output**, not its TS source. That package's own internal imports use a `./foo.js`-pointing-at-`./foo.ts` convention that's fine for Node/Vite's `Bundler` resolution but that plain Deno can't follow — and, critically, the **deployed `supabase-edge-runtime` doesn't support the `sloppy-imports` flag** that would otherwise paper over this for the local Deno CLI. I confirmed this the hard way: it type-checked and unit-tested fine with `src` + `sloppy-imports`, but the actual function failed to boot against a real local stack. Switched to `dist`, verified the full integration suite passes against a live `supabase start`.
- A handful of small, frozen wire-format types (`Player`, `Coordinate`, `Rules`, `SerializedGame`) are mirrored locally in `_shared/gameRow.ts` rather than imported, because Deno's checker can't resolve a `type`-only export re-exported through a `.js` specifier back to its real declaration. Documented as a deliberate trade-off in CLAUDE.md.
- `pnpm --filter @mintactoe/game-engine build` must run before `supabase start` (or `deno test`/`check` against `supabase/functions`) — wired into `pnpm dev:full` and both relevant CI jobs.

## Test plan
- [x] `deno test --allow-env --allow-net --config supabase/functions/deno.json supabase/functions` — 11/11 passing
- [x] `pnpm --filter @mintactoe/supabase-tests test` against a real local stack (built game-engine, `supabase start`) — 6/6 passing, including the new edge-functions integration suite
- [x] `pnpm --filter @mintactoe/game-engine test:coverage` — unaffected, still 100%/98.88% branch coverage
- [x] `deno check` on all three function entry points — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)